### PR TITLE
Setup stub before script execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ see specs in `spec/` folder:
 
 ```ruby
   let(:stubbed_env) { create_stubbed_env }
-  let(:bundle) { stubbed_env.stub_command('bundle') }
+  let!(:bundle) { stubbed_env.stub_command('bundle') }
   let(:rake) { bundle.with_args('exec', 'rake') }
 
   it 'is stubbed' do


### PR DESCRIPTION
I run into a situation where I followed the example but got a command not found because `let` is evaluated after the script finished executing.
