### PR TITLE
Fix called_with_args? on StubbedCommand

### DIFF
--- a/lib/rspec/shell/expectations/stubbed_command.rb
+++ b/lib/rspec/shell/expectations/stubbed_command.rb
@@ -24,7 +24,7 @@ module Rspec
         end
 
         def called_with_args?(*args)
-          with_args.called_with_args?(*args)
+          with_args(*args).called?
         end
 
         def returns_exitstatus(statuscode)


### PR DESCRIPTION
With this code:

``` ruby
require 'rspec/shell/expectations'

describe 'my shell script' do
  include Rspec::Shell::Expectations

  let(:stubbed_env) { create_stubbed_env }
  let!(:curl) { stubbed_env.stub_command('curl') }

  it 'runs the script' do
    stdout, stderr, status = stubbed_env.execute(
      './my-shell-script.sh'
    )

    puts curl.called_with_args?('--fail')
    expect(status.exitstatus).to eq 0
  end
end
```

I noticed that I was getting this exception:

```
NoMethodError:
       undefined method `called_with_args?' for <Stubbed "curl">:Rspec::Shell::Expectations::StubbedCall
```
